### PR TITLE
Feature/064 remove sleep from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,20 +8,13 @@ env:
 
 before_install:
   - sudo rm /usr/local/bin/docker-compose
-  - >
-    curl -L
-    https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m`
-    > docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
-
-before_install:
   - sudo /etc/init.d/mysql stop
   - sudo chmod -R 777 .
 
 install: ./docker/up
-
-before_script: sleep 30
 
 script:
   - docker exec -u www-data chloris_php bash -c 'phing build'

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
                 </then>
                 <else>
                     <echo message="Downloading composer ..." />
-                    <retry retrycount="3">
+                    <retry retryCount="3" retryDelay="5">
                         <exec executable="curl" checkreturn="true" passthru="true">
                             <arg value="https://getcomposer.org/composer.phar" />
                             <arg value="--output" />
@@ -24,22 +24,26 @@
                 </else>
             </if>
         <echo message="Running composer install ..." />
-        <exec executable="php" checkreturn="true" passthru="true">
-            <arg value="composer.phar" />
-            <arg value="install" />
-            <arg value="--no-suggest"/>
-            <arg value="--no-interaction" />
-        </exec>
+        <retry retryCount="3" retryDelay="5">
+            <exec executable="php" checkreturn="true" passthru="true">
+                <arg value="composer.phar" />
+                <arg value="install" />
+                <arg value="--no-suggest"/>
+                <arg value="--no-interaction" />
+            </exec>
+        </retry>
     </target>
     <!-- END -->
     <!-- DOCTRINE -->
     <target name="doctrine" depends="composer">
         <echo message="Drop database ..." />
-        <exec executable="bin/console" checkreturn="true">
-            <arg value="doctrine:database:drop" />
-            <arg value="--if-exists" />
-            <arg value="--force" />
-        </exec>
+        <retry retryCount="3" retryDelay="5">
+            <exec executable="bin/console" checkreturn="true">
+                <arg value="doctrine:database:drop" />
+                <arg value="--if-exists" />
+                <arg value="--force" />
+            </exec>
+        </retry>
         <echo message="Creating database ..." />
         <exec executable="bin/console" checkreturn="true">
             <arg value="doctrine:database:create" />


### PR DESCRIPTION
It was formerly needed because MySQL database needs long time to get up and running. Thanks to phing retry task, we can ask database every 5 seconds if its running.
